### PR TITLE
feature: add method save SystemChat in local Notification service

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -385,7 +385,7 @@
 		},
 		"/chats/chat-system": {
 			"get": {
-				"operationId": "ChatsController_getSystemChat",
+				"operationId": "ChatsController_getSystemChats",
 				"parameters": [],
 				"responses": {
 					"200": {

--- a/src/modules/chats/controllers/chats.controller.ts
+++ b/src/modules/chats/controllers/chats.controller.ts
@@ -63,9 +63,14 @@ export class ChatsController {
         this.chatsService.updateMaxUsersOnline(roomName, onlineUsers);
     }
 
+    @MessagePattern(TopicsEnum.PUT_SYSTEM_CHATS)
+    putSystemChats() {
+        this.chatsService.putSystemcChats();
+    }
+
     @Get('chat-system')
     @ApiData(ChatEntity)
-    getSystemChat(): Promise<DataResponse<string | ChatEntity>> {
-        return this.chatsService.getSystemChat();
+    getSystemChats(): Promise<DataResponse<string | ChatEntity[]>> {
+        return this.chatsService.getSystemChats();
     }
 }

--- a/src/modules/chats/services/chats.service.ts
+++ b/src/modules/chats/services/chats.service.ts
@@ -119,14 +119,25 @@ export class ChatsService {
         );
     }
 
-    async getSystemChat(): Promise<DataResponse<string | ChatEntity>> {
-        const systemChat = await this.chatsRepository.findOne(
+    async getSystemChats(): Promise<DataResponse<string | ChatEntity[]>> {
+        const systemChats = await this.chatsRepository.find(
             { type: ChatTypeEnum.IS_SYSTEM },
             { populate: ['message'] },
         );
 
-        if (!systemChat) return new DataResponse(MessageErrorLanguageEnum.CHAT_WITH_ID_NOT_FOUND);
+        if (!systemChats) return new DataResponse(MessageErrorLanguageEnum.CHAT_WITH_ID_NOT_FOUND);
 
-        return new DataResponse(systemChat);
+        return new DataResponse(systemChats);
+    }
+
+    async putSystemcChats() {
+        const response = await this.getSystemChats();
+        const chatIds = response.data instanceof Array ? response.data.map((chat) => chat.id) : [response.data];
+        this.queueService.sendMessage(
+            TopicsEnum.SYSTEM_CHATS,
+            undefined,
+            EventsEnum.GET_SYSTEM_CHAT,
+            new DataResponse(chatIds),
+        );
     }
 }

--- a/src/modules/chats/types/message-error-language.enum.ts
+++ b/src/modules/chats/types/message-error-language.enum.ts
@@ -3,4 +3,5 @@ export enum MessageErrorLanguageEnum {
     CHAT_NOT_FOUND = 'chat_not_found',
     PARENT_MESSAGE_NOT_FOUND = 'parent_message_not_found',
     SOME_CHATS_NOT_FOUND = 'some_chats_not_found',
+    MESSAGE_NOT_FOUND = 'message_not_found',
 }

--- a/src/modules/queue/dto/message.dto.ts
+++ b/src/modules/queue/dto/message.dto.ts
@@ -7,7 +7,7 @@ export class MessageDto {
     @IsString()
     @ApiProperty()
     @IsNotEmpty()
-    readonly to: string;
+    readonly to: string | undefined;
 
     @ApiProperty({ enum: EventsEnum })
     @IsEnum(EventsEnum)
@@ -16,7 +16,7 @@ export class MessageDto {
     @ApiProperty({ type: DataResponse<unknown> })
     readonly data: DataResponse<unknown>;
 
-    constructor(to: string, event: EventsEnum, data: DataResponse<unknown>) {
+    constructor(to: string | undefined, event: EventsEnum, data: DataResponse<unknown>) {
         this.to = to;
         this.event = event;
         this.data = data;

--- a/src/modules/queue/queue.service.ts
+++ b/src/modules/queue/queue.service.ts
@@ -29,7 +29,7 @@ export class QueueService {
         event: EventsEnum,
         data: DataResponse<unknown>,
     ): void {
-        if (!Envs.kafka.kafkaIsConnect || !this.isConnected || !to) return;
+        if (!Envs.kafka.kafkaIsConnect || !this.isConnected) return;
 
         const message = new MessageDto(to, event, data);
 

--- a/src/modules/queue/types/events.enum.ts
+++ b/src/modules/queue/types/events.enum.ts
@@ -3,4 +3,5 @@ export enum EventsEnum {
     CREATE_MESSAGE = 'create_message',
     JOIN_CHAT = 'join_chat',
     LEAVE_CHAT = 'leave_chat',
+    GET_SYSTEM_CHAT = 'get_system_chat',
 }

--- a/src/modules/queue/types/topics.enum.ts
+++ b/src/modules/queue/types/topics.enum.ts
@@ -3,4 +3,6 @@ export enum TopicsEnum {
     JOIN = 'join',
     LEAVE = 'leave',
     ONLINE = 'online',
+    SYSTEM_CHATS = 'system_chats',
+    PUT_SYSTEM_CHATS = 'put_system_chats',
 }


### PR DESCRIPTION
добавил контролеры которые принимают и отправляют сообщение в сервис уведомлений для локально сохранения массива id системных чатов
также исправил логику для системного(в будущем системных )чата, теперь при получении системного чата будет возвращается массив 
теперь в методе создания сообшения в кафку отправляется родительское сообщение 